### PR TITLE
DS-4943 add negative user sampling to DataLoaders

### DIFF
--- a/collie/interactions/dataloaders.py
+++ b/collie/interactions/dataloaders.py
@@ -188,9 +188,9 @@ class ApproximateNegativeSamplingInteractionsDataLoader(BaseInteractionsDataLoad
     dramatically speeds up a traditional DataLoader's process of calling ``__getitem__`` one index
     at a time, then concatenating them together before returning. In an effort to batch operations
     together, all negative samples returned will be approximate, meaning this does not check if a
-    user or item has previously interacted with the item or user. With a sufficient number of
-    interactions (1M+), we have found a speed increase of 2x at the cost of a 1% reduction in
-    MAP @ 10 performance compared to ``InteractionsDataLoader``.
+    user or item has previously interacted with the item or user, respectively. With a sufficient
+    number of interactions (1M+), we have found a speed increase of 2x at the cost of a 1% reduction
+    in MAP @ 10 performance compared to ``InteractionsDataLoader``.
 
     For greater efficiency, we disable automated batching by setting the DataLoader's
     ``batch_size`` attribute to ``None``. Thus,

--- a/collie/interactions/dataloaders.py
+++ b/collie/interactions/dataloaders.py
@@ -184,14 +184,13 @@ class ApproximateNegativeSamplingInteractionsDataLoader(BaseInteractionsDataLoad
     A computationally more efficient ``DataLoader`` for ``Interactions`` data using approximate
     negative sampling for negative items or users.
 
-    #TODO
     This DataLoader groups ``__getitem__`` calls together into a single operation, which
     dramatically speeds up a traditional DataLoader's process of calling ``__getitem__`` one index
     at a time, then concatenating them together before returning. In an effort to batch operations
     together, all negative samples returned will be approximate, meaning this does not check if a
-    user has previously interacted with the item. With a sufficient number of interactions (1M+), we
-    have found a speed increase of 2x at the cost of a 1% reduction in MAP @ 10 performance
-    compared to ``InteractionsDataLoader``.
+    user or item has previously interacted with the item or user. With a sufficient number of
+    interactions (1M+), we have found a speed increase of 2x at the cost of a 1% reduction in
+    MAP @ 10 performance compared to ``InteractionsDataLoader``.
 
     For greater efficiency, we disable automated batching by setting the DataLoader's
     ``batch_size`` attribute to ``None``. Thus,

--- a/collie/interactions/dataloaders.py
+++ b/collie/interactions/dataloaders.py
@@ -52,6 +52,11 @@ class BaseInteractionsDataLoader(torch.utils.data.DataLoader):
         return self.interactions.num_items
 
     @property
+    def negative_sample_type(self) -> int:
+        """Type of negative sample in ``interactions``."""
+        return self.interactions.negative_sample_type
+
+    @property
     def num_negative_samples(self) -> int:
         """Number of negative samples in ``interactions``."""
         return self.interactions.num_negative_samples
@@ -158,7 +163,8 @@ class InteractionsDataLoader(BaseInteractionsDataLoader):
         """String representation of ``InteractionsDataLoader`` class."""
         if hasattr(self.interactions, 'num_negative_samples'):
             extra_repr_str = (
-                f'{self.num_negative_samples} negative samples per implicit interaction in'
+                f'{self.num_negative_samples} negative {self.negative_sample_type} samples per'
+                ' implicit interaction in'
             )
         else:
             extra_repr_str = 'explicit,'
@@ -176,8 +182,9 @@ class InteractionsDataLoader(BaseInteractionsDataLoader):
 class ApproximateNegativeSamplingInteractionsDataLoader(BaseInteractionsDataLoader):
     """
     A computationally more efficient ``DataLoader`` for ``Interactions`` data using approximate
-    negative sampling for negative items.
+    negative sampling for negative items or users.
 
+    #TODO
     This DataLoader groups ``__getitem__`` calls together into a single operation, which
     dramatically speeds up a traditional DataLoader's process of calling ``__getitem__`` one index
     at a time, then concatenating them together before returning. In an effort to batch operations
@@ -287,8 +294,8 @@ class ApproximateNegativeSamplingInteractionsDataLoader(BaseInteractionsDataLoad
             f'''
             ApproximateNegativeSamplingInteractionsDataLoader object with {self.num_interactions}
             interactions between {self.num_users} users and {self.num_items} items, returning
-            {self.num_negative_samples} negative samples per implicit interaction in
-            {'shuffled' if self.shuffle else 'non-shuffled'} batches of size
+            {self.num_negative_samples} negative {self.negative_sample_type} samples per implicit
+            interaction in {'shuffled' if self.shuffle else 'non-shuffled'} batches of size
             {self.approximate_negative_sampler.batch_size}.
             '''
         ).replace('\n', ' ').strip()

--- a/collie/interactions/dataloaders.py
+++ b/collie/interactions/dataloaders.py
@@ -398,7 +398,8 @@ class HDF5InteractionsDataLoader(BaseInteractionsDataLoader):
             HDF5InteractionsDataLoader object with {self.interactions.num_interactions}
             interactions between {self.interactions.num_users} users and
             {self.interactions.num_items} items, returning {self.num_negative_samples} negative
-            samples per implicit interaction in {'shuffled' if self.shuffle else 'non-shuffled'}
+            {self.negative_sample_type} samples per implicit interaction in
+            {'shuffled' if self.shuffle else 'non-shuffled'}
             batches of size {self.hdf5_sampler.batch_size}.
             '''
         ).replace('\n', ' ').strip()

--- a/collie/interactions/datasets.py
+++ b/collie/interactions/datasets.py
@@ -318,10 +318,10 @@ class Interactions(BaseInteractions):
         if seed is None:
             seed = collie.utils.get_random_seed()
 
-        if self.negative_sample_type not in ('item', 'user'):
+        if negative_sample_type not in ('item', 'user'):
             raise ValueError(
                 '``negative_sample_type`` must be either ``item`` or ``user``, not '
-                f'``{self.negative_sample_type}``!'
+                f'``{negative_sample_type}``!'
             )
 
         self.negative_sample_type = negative_sample_type
@@ -673,10 +673,10 @@ class HDF5Interactions(torch.utils.data.Dataset):
                  num_items: int = 'infer',
                  seed: Optional[int] = None,
                  shuffle: bool = False):
-        if self.negative_sample_type not in ('item', 'user'):
+        if negative_sample_type not in ('item', 'user'):
             raise ValueError(
                 '``negative_sample_type`` must be either ``item`` or ``user``, not '
-                f'{self.negative_sample_type}!'
+                f'{negative_sample_type}!'
             )
 
         self.hdf5_path = hdf5_path

--- a/collie/interactions/samplers.py
+++ b/collie/interactions/samplers.py
@@ -10,7 +10,8 @@ from collie.interactions.datasets import HDF5Interactions, Interactions
 
 class ApproximateNegativeSampler(torch.utils.data.sampler.Sampler):
     """
-    Custom ``Sampler`` for bulk-sampling approximate negative items in ``Interactions`` data.
+    Custom ``Sampler`` for bulk-sampling approximate negative items or users in ``Interactions``
+    data.
 
     Parameters
     ----------

--- a/tests/fixtures/interactions_fixtures.py
+++ b/tests/fixtures/interactions_fixtures.py
@@ -91,23 +91,31 @@ def df_for_interactions_with_duplicates():
     })
 
 
+@pytest.fixture(params=['user', 'item'])
+def negative_sample_types(request):
+    return request.param
+
+
 @pytest.fixture()
-def interactions_pandas(df_for_interactions):
+def interactions_pandas(df_for_interactions, negative_sample_types):
     return Interactions(users=df_for_interactions['user_id'],
                         items=df_for_interactions['item_id'],
                         ratings=df_for_interactions['ratings'],
+                        negative_sample_type=negative_sample_types,
                         check_num_negative_samples_is_valid=False)
 
 
 @pytest.fixture()
-def interactions_matrix(ratings_matrix_for_interactions):
+def interactions_matrix(ratings_matrix_for_interactions, negative_sample_types):
     return Interactions(mat=ratings_matrix_for_interactions,
+                        negative_sample_type=negative_sample_types,
                         check_num_negative_samples_is_valid=False)
 
 
 @pytest.fixture()
-def interactions_sparse_matrix(sparse_ratings_matrix_for_interactions):
+def interactions_sparse_matrix(sparse_ratings_matrix_for_interactions, negative_sample_types):
     return Interactions(mat=sparse_ratings_matrix_for_interactions,
+                        negative_sample_type=negative_sample_types,
                         check_num_negative_samples_is_valid=False)
 
 

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -210,7 +210,7 @@ class TestBadInteractionsInstantiation:
                      check_num_negative_samples_is_valid=False)
 
     def test_ratings_None_but_its_explicit_so_not_okay(self, df_for_interactions):
-        with pytest.raises(ValueError, match=(
+        with pytest.raises(ValueError, match=re.escape(
             'Ratings must be provided to ``ExplicitInteractions`` with ``mat`` or ``ratings``'
             ' - both cannot be ``None``!'
         )):
@@ -259,7 +259,7 @@ class TestBadInteractionsInstantiation:
         assert non_duplicated_interactions.mat.getnnz() == explicit_interactions_pandas.mat.getnnz()
 
     def test_bad_negative_sample_type(self, df_for_interactions):
-        with pytest.raises(ValueError, match=(
+        with pytest.raises(ValueError, match=re.escape(
             '``negative_sample_type`` must be either ``item`` or ``user``, not ``users``!'
         )):
             Interactions(users=df_for_interactions['user_id'],

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 import numpy as np
@@ -185,7 +186,7 @@ def test_ExplicitInteractions_with_0_ratings(explicit_interactions_pandas,
 
 class TestBadInteractionsInstantiation:
     def test_items_None(self, df_for_interactions):
-        with pytest.raises(AssertionError, match=(
+        with pytest.raises(AssertionError, match=re.escape(
             'Either 1) ``mat`` or 2) both ``users`` or ``items`` must be non-null!'
         )):
             Interactions(users=df_for_interactions['user_id'],
@@ -194,7 +195,7 @@ class TestBadInteractionsInstantiation:
                          check_num_negative_samples_is_valid=False)
 
     def test_users_None(self, df_for_interactions):
-        with pytest.raises(AssertionError, match=(
+        with pytest.raises(AssertionError, match=re.escape(
             'Either 1) ``mat`` or 2) both ``users`` or ``items`` must be non-null!'
         )):
             Interactions(users=None,

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -13,7 +13,7 @@ from collie.interactions import (ApproximateNegativeSamplingInteractionsDataLoad
 
 
 NUM_NEGATIVE_SAMPLES = 3
-NUM_USERS_TO_GENERATE = 10
+NUM_USERS_OR_ITEMS_TO_GENERATE = 10
 
 
 # @pytest.mark.parametrize('negative_sample_type', ['item', 'user'])
@@ -374,7 +374,7 @@ class TestInteractionsNegativeSampling:
 
             assert len(negative_samples) == 3
 
-    def test_Interactions_approximate_negative_samples_many_users(
+    def test_Interactions_approximate_negative_samples_many_users_or_items(
         self,
         ratings_matrix_for_interactions,
         negative_sample_type,
@@ -388,9 +388,9 @@ class TestInteractionsNegativeSampling:
         assert interactions.positive_sets == {}
 
         for _ in range(3):
-            _, negative_samples = interactions[list(range(NUM_USERS_TO_GENERATE))]
+            _, negative_samples = interactions[list(range(NUM_USERS_OR_ITEMS_TO_GENERATE))]
 
-            assert len(negative_samples) == NUM_USERS_TO_GENERATE
+            assert len(negative_samples) == NUM_USERS_OR_ITEMS_TO_GENERATE
 
             for negative_sample in negative_samples:
                 assert len(negative_sample) == NUM_NEGATIVE_SAMPLES
@@ -447,7 +447,7 @@ class TestInteractionsNegativeSampling:
 
         assert len(set(all_negative_samples)) > NUM_NEGATIVE_SAMPLES
 
-    def test_Interactions_exact_negative_samples_many_users(
+    def test_Interactions_exact_negative_samples_many_users_or_items(
         self,
         ratings_matrix_for_interactions,
         negative_sample_type,
@@ -462,10 +462,10 @@ class TestInteractionsNegativeSampling:
 
         for _ in range(10):
             (user_ids, item_ids), negative_samples = (
-                interactions[list(range(NUM_USERS_TO_GENERATE))]
+                interactions[list(range(NUM_USERS_OR_ITEMS_TO_GENERATE))]
             )
 
-            assert len(negative_samples) == NUM_USERS_TO_GENERATE
+            assert len(negative_samples) == NUM_USERS_OR_ITEMS_TO_GENERATE
 
             if negative_sample_type == 'item':
                 for idx, user_id in enumerate(user_ids):


### PR DESCRIPTION
## Describe the big picture - why are we doing this?
Collie currently has the ability to sample negative items for given users in implicit model training. We would like to add the option to sample negative items instead (and both in the future). This PR adds the option to the `Interactions` and `DataLoader` classes. I purposely did not edit the `changelog` nor `_version`, I will save that for the final PR when all the parts of negative user sampling have been added. 

## Any additional details to clarify code in the PR?

## How is this tested?
On an EC2 instance in Docker, all tests pass.

## Pull Request Checklist
 - [x] Pull request includes a description of why we are doing this
 - [ ] ``CHANGELOG`` has been updated
 - [ ] Version in ``_version.py`` has been updated
 - [x] All tests in the ``tests`` folder pass with a local build
 - [ ] ``README`` has been updated (if applicable)
 - [ ] Documentation in ``docs`` has been updated (if applicable)
 - [ ] ``requirements.txt`` and ``requirements-dev.txt`` have been recompiled (if applicable)
 - [ ] Docker image can be built using ``docker build -t collie .``

## Screenshots or GIFs?
![](https://media3.giphy.com/media/xUPGcoj2LKAkDOSahG/giphy.gif?cid=ecf05e47counbk83nf234wkz5eknxkh3gewk0tqkwn802a2e&rid=giphy.gif&ct=g)