### PR TITLE
DS-4946 add negative user sampling to modeling in collie

### DIFF
--- a/collie/cross_validation.py
+++ b/collie/cross_validation.py
@@ -29,6 +29,7 @@ def _subset_interactions(interactions: BaseInteractions,
     if isinstance(interactions, Interactions):
         return Interactions(
             mat=coo_mat,
+            negative_sample_type=interactions.negative_sample_type,
             num_negative_samples=interactions.num_negative_samples,
             allow_missing_ids=True,
             remove_duplicate_user_item_pairs=False,

--- a/collie/loss/bpr.py
+++ b/collie/loss/bpr.py
@@ -8,9 +8,9 @@ from collie.loss.metadata_utils import ideal_difference_from_metadata
 def bpr_loss(
     positive_scores: torch.tensor,
     negative_scores: torch.tensor,
-    num_items: Optional[Any] = None,
-    positive_items: Optional[torch.tensor] = None,
-    negative_items: Optional[torch.tensor] = None,
+    num_ids: Optional[Any] = None,
+    positive_ids: Optional[torch.tensor] = None,
+    negative_ids: Optional[torch.tensor] = None,
     metadata: Optional[Dict[str, torch.tensor]] = dict(),
     metadata_weights: Optional[Dict[str, float]] = dict(),
 ) -> torch.tensor:
@@ -28,21 +28,22 @@ def bpr_loss(
     Parameters
     ----------
     positive_scores: torch.tensor, 1-d
-        Tensor containing predictions for known positive items of shape ``1 x batch_size``
+        Tensor containing predictions for known positive items or users of shape ``1 x batch_size``
     negative_scores: torch.tensor, 1-d
-        Tensor containing scores for a single sampled negative item of shape ``1 x batch_size``
-    num_items: Any
+        Tensor containing scores for a single sampled negative item or user of shape
+        ``1 x batch_size``
+    num_ids: Any
         Ignored, included only for compatability with WARP loss
-    positive_items: torch.tensor, 1-d
-        Tensor containing ids for known positive items of shape ``1 x batch_size``. This is only
-        needed if ``metadata`` is provided
-    negative_items: torch.tensor, 1-d
-        Tensor containing ids for randomly-sampled negative items of shape ``1 x batch_size``. This
-        is only needed if ``metadata`` is provided
+    positive_ids: torch.tensor, 1-d
+        Tensor containing IDs for known positive items or users of shape ``1 x batch_size``. This is
+        only needed if ``metadata`` is provided
+    negative_ids: torch.tensor, 1-d
+        Tensor containing IDs for randomly-sampled negative items or users of shape
+        ``1 x batch_size``. This is only needed if ``metadata`` is provided
     metadata: dict
         Keys should be strings identifying each metadata type that match keys in
-        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_items x 1). Each
-        tensor should contain categorical metadata information about items (e.g. a number
+        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_ids x 1). Each
+        tensor should contain categorical metadata information about items or users (e.g. a number
         representing the genre of the item)
     metadata_weights: dict
         Keys should be strings identifying each metadata type that match keys in ``metadata``.
@@ -76,8 +77,8 @@ def bpr_loss(
 
     if metadata is not None and len(metadata) > 0:
         ideal_difference = ideal_difference_from_metadata(
-            positive_items=positive_items,
-            negative_items=negative_items,
+            positive_ids=positive_ids,
+            negative_ids=negative_ids,
             metadata=metadata,
             metadata_weights=metadata_weights,
         )
@@ -92,9 +93,9 @@ def bpr_loss(
 def adaptive_bpr_loss(
     positive_scores: torch.tensor,
     many_negative_scores: torch.tensor,
-    num_items: Optional[Any] = None,
-    positive_items: Optional[torch.tensor] = None,
-    negative_items: Optional[torch.tensor] = None,
+    num_ids: Optional[Any] = None,
+    positive_ids: Optional[torch.tensor] = None,
+    negative_ids: Optional[torch.tensor] = None,
     metadata: Optional[Dict[str, torch.tensor]] = dict(),
     metadata_weights: Optional[Dict[str, float]] = dict(),
 ) -> torch.tensor:
@@ -109,24 +110,24 @@ def adaptive_bpr_loss(
     Parameters
     ----------
     positive_scores: torch.tensor, 1-d
-        Tensor containing scores for known positive items of shape
+        Tensor containing scores for known positive items or users of shape
         ``num_negative_samples x batch_size``
     many_negative_scores: torch.tensor, 2-d
-        Iterable of tensors containing scores for many (n > 1) sampled negative items of shape
-        ``num_negative_samples x batch_size``. More tensors increase the likelihood of finding
+        Iterable of tensors containing scores for many (n > 1) sampled negative items or users of
+        shape ``num_negative_samples x batch_size``. More tensors increase the likelihood of finding
         ranking-violating pairs, but risk overfitting
-    num_items: Any
+    num_ids: Any
         Ignored, included only for compatability with WARP loss
-    positive_items: torch.tensor, 1-d
-        Tensor containing ids for known positive items of shape
+    positive_ids: torch.tensor, 1-d
+        Tensor containing IDs for known positive items or users of shape
         ``num_negative_samples x batch_size``. This is only needed if ``metadata`` is provided
-    negative_items: torch.tensor, 2-d
-        Tensor containing ids for sampled negative items of shape
+    negative_ids: torch.tensor, 2-d
+        Tensor containing IDs for sampled negative items or users of shape
         ``num_negative_samples x batch_size``. This is only needed if ``metadata`` is provided
     metadata: dict
         Keys should be strings identifying each metadata type that match keys in
-        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_items x 1). Each
-        tensor should contain categorical metadata information about items (e.g. a number
+        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_ids x 1). Each
+        tensor should contain categorical metadata information about items or users (e.g. a number
         representing the genre of the item)
     metadata_weights: dict
         Keys should be strings identifying each metadata type that match keys in ``metadata``.
@@ -152,16 +153,16 @@ def adaptive_bpr_loss(
     """
     highest_negative_scores, highest_negative_inds = torch.max(many_negative_scores, 0)
 
-    if negative_items is not None and positive_items is not None:
-        negative_items = (
-            negative_items[highest_negative_inds, torch.arange(len(positive_items))].squeeze()
+    if negative_ids is not None and positive_ids is not None:
+        negative_ids = (
+            negative_ids[highest_negative_inds, torch.arange(len(positive_ids))].squeeze()
         )
 
     return bpr_loss(
         positive_scores,
         highest_negative_scores.squeeze(),
-        positive_items=positive_items,
-        negative_items=negative_items,
+        positive_ids=positive_ids,
+        negative_ids=negative_ids,
         metadata=metadata,
         metadata_weights=metadata_weights,
     )

--- a/collie/loss/hinge.py
+++ b/collie/loss/hinge.py
@@ -8,9 +8,9 @@ from collie.loss.metadata_utils import ideal_difference_from_metadata
 def hinge_loss(
     positive_scores: torch.tensor,
     negative_scores: torch.tensor,
-    num_items: Optional[Any] = None,
-    positive_items: Optional[torch.tensor] = None,
-    negative_items: Optional[torch.tensor] = None,
+    num_ids: Optional[Any] = None,
+    positive_ids: Optional[torch.tensor] = None,
+    negative_ids: Optional[torch.tensor] = None,
     metadata: Optional[Dict[str, torch.tensor]] = dict(),
     metadata_weights: Optional[Dict[str, float]] = dict(),
 ) -> torch.tensor:
@@ -25,21 +25,21 @@ def hinge_loss(
     Parameters
     ----------
     positive_scores: torch.tensor, 1-d
-        Tensor containing scores for known positive items
+        Tensor containing scores for known positive items or users
     negative_scores: torch.tensor, 1-d
-        Tensor containing scores for a single sampled negative item
-    num_items: Any
+        Tensor containing scores for a single sampled negative item or user
+    num_ids: Any
         Ignored, included only for compatability with WARP loss
-    positive_items: torch.tensor, 1-d
-        Tensor containing ids for known positive items of shape ``1 x batch_size``. This is only
-        needed if ``metadata`` is provided
-    negative_items: torch.tensor, 1-d
-        Tensor containing ids for randomly-sampled negative items of shape ``1 x batch_size``. This
-        is only needed if ``metadata`` is provided
+    positive_ids: torch.tensor, 1-d
+        Tensor containing IDs for known positive items or users of shape ``1 x batch_size``. This is
+        only needed if ``metadata`` is provided
+    negative_ids: torch.tensor, 1-d
+        Tensor containing IDs for randomly-sampled negative items or users of shape
+        ``1 x batch_size``. This is only needed if ``metadata`` is provided
     metadata: dict
         Keys should be strings identifying each metadata type that match keys in
-        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_items x 1). Each
-        tensor should contain categorical metadata information about items (e.g. a number
+        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_ids x 1). Each
+        tensor should contain categorical metadata information about items or users (e.g. a number
         representing the genre of the item)
     metadata_weights: dict
         Keys should be strings identifying each metadata type that match keys in ``metadata``.
@@ -72,8 +72,8 @@ def hinge_loss(
 
     if metadata is not None and len(metadata) > 0:
         ideal_difference = ideal_difference_from_metadata(
-            positive_items=positive_items,
-            negative_items=negative_items,
+            positive_ids=positive_ids,
+            negative_ids=negative_ids,
             metadata=metadata,
             metadata_weights=metadata_weights,
         )
@@ -88,9 +88,9 @@ def hinge_loss(
 def adaptive_hinge_loss(
     positive_scores: torch.tensor,
     many_negative_scores: torch.tensor,
-    num_items: Optional[Any] = None,
-    positive_items: Optional[torch.tensor] = None,
-    negative_items: Optional[torch.tensor] = None,
+    num_ids: Optional[Any] = None,
+    positive_ids: Optional[torch.tensor] = None,
+    negative_ids: Optional[torch.tensor] = None,
     metadata: Optional[Dict[str, torch.tensor]] = dict(),
     metadata_weights: Optional[Dict[str, float]] = dict(),
 ) -> torch.tensor:
@@ -108,24 +108,24 @@ def adaptive_hinge_loss(
     Parameters
     ----------
     positive_scores: torch.tensor, 1-d
-        Tensor containing scores for known positive items of shape
+        Tensor containing scores for known positive items or users of shape
         ``num_negative_samples x batch_size``
     many_negative_scores: torch.tensor, 2-d
-        Iterable of tensors containing scores for many (n > 1) sampled negative items of shape
-        ``num_negative_samples x batch_size``. More tensors increase the likelihood of finding
+        Iterable of tensors containing scores for many (n > 1) sampled negative items or users of
+        shape ``num_negative_samples x batch_size``. More tensors increase the likelihood of finding
         ranking-violating pairs, but risk overfitting
-    num_items: Any
+    num_ids: Any
         Ignored, included only for compatability with WARP loss
-    positive_items: torch.tensor, 1-d
-        Tensor containing ids for known positive items of shape
+    positive_ids: torch.tensor, 1-d
+        Tensor containing IDs for known positive items or users of shape
         ``num_negative_samples x batch_size``. This is only needed if ``metadata`` is provided
-    negative_items: torch.tensor, 2-d
-        Tensor containing ids for sampled negative items of shape
+    negative_ids: torch.tensor, 2-d
+        Tensor containing IDs for sampled negative items or users of shape
         ``num_negative_samples x batch_size``. This is only needed if ``metadata`` is provided
     metadata: dict
         Keys should be strings identifying each metadata type that match keys in
-        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_items x 1). Each
-        tensor should contain categorical metadata information about items (e.g. a number
+        ``metadata_weights``. Values should be a ``torch.tensor`` of shape (num_ids x 1). Each
+        tensor should contain categorical metadata information about items or users (e.g. a number
         representing the genre of the item)
     metadata_weights: dict
         Keys should be strings identifying each metadata type that match keys in ``metadata``.
@@ -156,16 +156,16 @@ def adaptive_hinge_loss(
     """
     highest_negative_scores, highest_negative_inds = torch.max(many_negative_scores, 0)
 
-    if negative_items is not None and positive_items is not None:
-        negative_items = (
-            negative_items[highest_negative_inds, torch.arange(len(positive_items))].squeeze()
+    if negative_ids is not None and positive_ids is not None:
+        negative_ids = (
+            negative_ids[highest_negative_inds, torch.arange(len(positive_ids))].squeeze()
         )
 
     return hinge_loss(
         positive_scores,
         highest_negative_scores.squeeze(),
-        positive_items=positive_items,
-        negative_items=negative_items,
+        positive_ids=positive_ids,
+        negative_ids=negative_ids,
         metadata=metadata,
         metadata_weights=metadata_weights,
     )

--- a/collie/loss/metadata_utils.py
+++ b/collie/loss/metadata_utils.py
@@ -10,7 +10,7 @@ def ideal_difference_from_metadata(
     metadata_weights: Optional[Dict[str, float]],
 ) -> torch.tensor:
     """
-    Helper function to calculate the ideal score difference between the positive and negative ids.
+    Helper function to calculate the ideal score difference between the positive and negative IDs.
 
     Without considering metadata, the ideal score difference would be 1.0 (since the function looks
     at a pair of items or users, one positive item and one negative item or one positive user and

--- a/collie/model/base/base_pipeline.py
+++ b/collie/model/base/base_pipeline.py
@@ -180,13 +180,26 @@ class BasePipeline(LightningModule, metaclass=ABCMeta):
                 )
 
                 if (
+                    hasattr(self.train_loader, 'negative_sample_type')
+                    or hasattr(self.val_loader, 'negative_sample_type')
+                ):
+                    assert self.train_loader.negative_sample_type == \
+                        self.val_loader.negative_sample_type, (
+                            'Training and val ``negative_sample_type`` property must both equal '
+                            '``item`` or both equal ``user``, not: '
+                            f'{self.train_loader.negative_sample_type}'
+                            f' and {self.val_loader.negative_sample_type}, respectively.'
+                        )
+
+                if (
                     hasattr(self.train_loader, 'num_negative_samples')
                     or hasattr(self.val_loader, 'num_negative_samples')
                 ):
                     num_negative_samples_error = (
                         'Training and val ``num_negative_samples`` property must both equal ``1``'
-                        f' or both be greater than ``1``, not: {self.train_loader.num_items} and'
-                        f' {self.val_loader.num_items}, respectively.'
+                        ' or both be greater than ``1``, not: '
+                        f'{self.train_loader.num_negative_samples}'
+                        f' and {self.val_loader.num_negative_samples}, respectively.'
                     )
                     if self.train_loader.num_negative_samples == 1:
                         assert self.val_loader.num_negative_samples == 1, num_negative_samples_error
@@ -275,7 +288,12 @@ class BasePipeline(LightningModule, metaclass=ABCMeta):
 
         # followed by implicit losses
         self.hparams._is_implicit = True
-        if not hasattr(self.train_loader, 'num_negative_samples'):
+        if not hasattr(self.train_loader, 'negative_sample_type'):
+            raise ValueError(
+                '``negative_sample_type`` attribute not found in ``train_loader`` - are you using '
+                'explicit data with an implicit loss function?'
+            )
+        elif not hasattr(self.train_loader, 'num_negative_samples'):
             raise ValueError(
                 '``num_negative_samples`` attribute not found in ``train_loader`` - are you using '
                 'explicit data with an implicit loss function?'
@@ -571,7 +589,7 @@ class BasePipeline(LightningModule, metaclass=ABCMeta):
               - Expected Meaning
               - Model Type
             * - ``((X, Y), Z)``
-              - ``((user IDs, item IDs), negative item IDs)``
+              - ``((user IDs, item IDs), negative item or user IDs)``
               - **Implicit**
             * - ``(X, Y, Z)``
               - ``(user IDs, item IDs, ratings)``
@@ -583,30 +601,40 @@ class BasePipeline(LightningModule, metaclass=ABCMeta):
                 raise ValueError('Explicit loss with implicit data is invalid!')
 
             # implicit data
-            ((users, pos_items), neg_items) = batch
+            ((users, items), neg_ids) = batch
 
             users = users.long()
-            pos_items = pos_items.long()
+            items = items.long()
             # TODO: see if there is a way to not have to transpose each time - probably a bit costly
-            neg_items = torch.transpose(neg_items, 0, 1).long()
+            neg_ids = torch.transpose(neg_ids, 0, 1).long()
 
             # get positive item predictions from model
-            pos_preds = self(users, pos_items)
+            pos_preds = self(users, items)
 
-            # get negative item predictions from model
-            users_repeated = users.repeat(neg_items.shape[0])
-            neg_items_flattened = neg_items.flatten()
-            neg_preds = self(users_repeated, neg_items_flattened).view(
-                neg_items.shape[0], len(users)
-            )
+            # get negative predictions from model
+            neg_ids_flattened = neg_ids.flatten()
+            if self.train_loader.negative_sample_type == 'item':
+                users_repeated = users.repeat(neg_ids.shape[0])
+                neg_preds = self(users_repeated, neg_ids_flattened).view(
+                    neg_ids.shape[0], len(users)
+                )
+                pos_ids = users
+                num_ids = self.hparams.num_items,
+            elif self.train_loader.negative_sample_type == 'user':
+                items_repeated = items.repeat(neg_ids.shape[0])
+                neg_preds = self(neg_ids_flattened, items_repeated).view(
+                    neg_ids.shape[0], len(items)  # TODO does this need to switch?
+                )
+                pos_ids = items
+                num_ids = self.hparams.num_users,
 
             # implicit loss function
             loss = self.loss_function(
                 pos_preds,
                 neg_preds,
-                num_items=self.hparams.num_items,
-                positive_items=pos_items,
-                negative_items=neg_items,
+                num_ids=num_ids,
+                positive_items=pos_ids,
+                negative_items=neg_ids,
                 metadata=self.hparams.metadata_for_loss,
                 metadata_weights=self.hparams.metadata_for_loss_weights,
             )

--- a/collie/model/base/base_pipeline.py
+++ b/collie/model/base/base_pipeline.py
@@ -185,10 +185,9 @@ class BasePipeline(LightningModule, metaclass=ABCMeta):
                 ):
                     assert self.train_loader.negative_sample_type == \
                         self.val_loader.negative_sample_type, (
-                            'Training and val ``negative_sample_type`` property must both equal '
-                            '``item`` or both equal ``user``, not: '
-                            f'{self.train_loader.negative_sample_type}'
-                            f' and {self.val_loader.negative_sample_type}, respectively.'
+                            'Training and val ``negative_sample_type`` property must be equal: '
+                            f'{self.train_loader.negative_sample_type} != '
+                            f'{self.val_loader.negative_sample_type}.'
                         )
 
                 if (

--- a/collie/model/base/base_pipeline.py
+++ b/collie/model/base/base_pipeline.py
@@ -619,22 +619,22 @@ class BasePipeline(LightningModule, metaclass=ABCMeta):
                     neg_ids.shape[0], len(users)
                 )
                 pos_ids = users
-                num_ids = self.hparams.num_items,
+                num_ids = self.hparams.num_items
             elif self.train_loader.negative_sample_type == 'user':
                 items_repeated = items.repeat(neg_ids.shape[0])
                 neg_preds = self(neg_ids_flattened, items_repeated).view(
-                    neg_ids.shape[0], len(items)  # TODO does this need to switch?
+                    neg_ids.shape[0], len(items)
                 )
                 pos_ids = items
-                num_ids = self.hparams.num_users,
+                num_ids = self.hparams.num_users
 
             # implicit loss function
             loss = self.loss_function(
                 pos_preds,
                 neg_preds,
                 num_ids=num_ids,
-                positive_items=pos_ids,
-                negative_items=neg_ids,
+                positive_ids=pos_ids,
+                negative_ids=neg_ids,
                 metadata=self.hparams.metadata_for_loss,
                 metadata_weights=self.hparams.metadata_for_loss_weights,
             )

--- a/tests/fixtures/loss_fixtures.py
+++ b/tests/fixtures/loss_fixtures.py
@@ -12,17 +12,17 @@ SCORES = torch.tensor([
 
 
 @pytest.fixture()
-def positive_items():
+def positive_ids():
     return torch.tensor([0, 1, 2, 3])
 
 
 @pytest.fixture()
-def negative_items():
+def negative_ids():
     return torch.tensor([4, 5, 6, 7])
 
 
 @pytest.fixture()
-def many_negative_items():
+def many_negative_ids():
     return torch.tensor([
         [4, 5, 6, 7],
         [8, 9, 10, 11],
@@ -32,18 +32,18 @@ def many_negative_items():
 
 
 @pytest.fixture()
-def positive_scores(positive_items):
-    return SCORES[positive_items]
+def positive_scores(positive_ids):
+    return SCORES[positive_ids]
 
 
 @pytest.fixture()
-def negative_scores(negative_items):
-    return SCORES[negative_items]
+def negative_scores(negative_ids):
+    return SCORES[negative_ids]
 
 
 @pytest.fixture()
-def many_negative_scores(many_negative_items):
-    return SCORES[many_negative_items]
+def many_negative_scores(many_negative_ids):
+    return SCORES[many_negative_ids]
 
 
 @pytest.fixture()

--- a/tests/fixtures/model_fixtures.py
+++ b/tests/fixtures/model_fixtures.py
@@ -60,6 +60,50 @@ def implicit_model_no_lightning(train_val_implicit_data, gpu_count):
 
 
 @pytest.fixture(scope='session')
+def implicit_model_user_negative_sample_type(
+    train_val_implicit_data_user_negative_sample_type,
+    gpu_count
+):
+    train, val = train_val_implicit_data_user_negative_sample_type
+    model = MatrixFactorizationModel(train=train,
+                                     val=val,
+                                     embedding_dim=10,
+                                     lr=1e-1)
+    model_trainer = CollieTrainer(model=model,
+                                  gpus=gpu_count,
+                                  max_epochs=10,
+                                  deterministic=True,
+                                  logger=False,
+                                  enable_checkpointing=False)
+    model_trainer.fit(model)
+    model.eval()
+
+    return model
+
+
+@pytest.fixture(scope='session')
+def implicit_model_no_lightning_user_negative_sample_type(
+    train_val_implicit_data_user_negative_sample_type,
+    gpu_count
+):
+    train, val = train_val_implicit_data_user_negative_sample_type
+    model = MatrixFactorizationModel(train=train,
+                                     val=val,
+                                     embedding_dim=10,
+                                     lr=1e-1)
+    model_trainer = CollieMinimalTrainer(model=model,
+                                         gpus=gpu_count,
+                                         max_epochs=10,
+                                         deterministic=True,
+                                         logger=False,
+                                         early_stopping_patience=False)
+    model_trainer.fit(model)
+    model.freeze()
+
+    return model
+
+
+@pytest.fixture(scope='session')
 def explicit_model(train_val_explicit_data, gpu_count):
     train, val = train_val_explicit_data
     model = MatrixFactorizationModel(train=train,

--- a/tests/fixtures/movielens_fixtures.py
+++ b/tests/fixtures/movielens_fixtures.py
@@ -51,6 +51,19 @@ def movielens_implicit_interactions(movielens_implicit_df):
 
 
 @pytest.fixture(scope='session')
+def movielens_implicit_interactions_user_negative_sample_type(
+    movielens_implicit_df
+):
+    return Interactions(users=movielens_implicit_df['user_id'],
+                        items=movielens_implicit_df['item_id'],
+                        ratings=movielens_implicit_df['rating'],
+                        negative_sample_type='user',
+                        num_negative_samples=10,
+                        max_number_of_samples_to_consider=200,
+                        allow_missing_ids=True)
+
+
+@pytest.fixture(scope='session')
 def movielens_explicit_interactions(movielens_explicit_df):
     return ExplicitInteractions(users=movielens_explicit_df['user_id'],
                                 items=movielens_explicit_df['item_id'],
@@ -67,6 +80,18 @@ def train_val_implicit_pandas_data(movielens_implicit_df):
 def train_val_implicit_data(movielens_implicit_interactions):
     return stratified_split(
         interactions=movielens_implicit_interactions,
+        val_p=0.,
+        test_p=0.2,
+        seed=42,
+    )
+
+
+@pytest.fixture(scope='session')
+def train_val_implicit_data_user_negative_sample_type(
+    movielens_implicit_interactions_user_negative_sample_type
+):
+    return stratified_split(
+        interactions=movielens_implicit_interactions_user_negative_sample_type,
         val_p=0.,
         test_p=0.2,
         seed=42,

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -11,8 +11,8 @@ from collie.loss import (adaptive_bpr_loss,
 
 
 def test_ideal_difference_from_metadata_error(
-    positive_items,
-    negative_items,
+    positive_ids,
+    negative_ids,
     metadata_a,
     metadata_b,
 ):
@@ -21,22 +21,22 @@ def test_ideal_difference_from_metadata_error(
         match='sum of metadata weights was 1.1, must be <=1'
     ):
         ideal_difference_from_metadata(
-            positive_items=positive_items,
-            negative_items=negative_items,
+            positive_ids=positive_ids,
+            negative_ids=negative_ids,
             metadata={'a': metadata_a, 'b': metadata_b},
             metadata_weights={'a': .2, 'b': .9},
         )
 
 
 def test_ideal_difference_from_metadata_a(
-    positive_items,
-    negative_items,
+    positive_ids,
+    negative_ids,
     metadata_a,
     metadata_a_diff,
 ):
     ideal_diff = ideal_difference_from_metadata(
-        positive_items=positive_items,
-        negative_items=negative_items,
+        positive_ids=positive_ids,
+        negative_ids=negative_ids,
         metadata={'a': metadata_a},
         metadata_weights={'a': .2},
     )
@@ -45,14 +45,14 @@ def test_ideal_difference_from_metadata_a(
 
 
 def test_ideal_difference_from_metadata_no_matches(
-    positive_items,
-    negative_items,
+    positive_ids,
+    negative_ids,
     metadata_a,
     metadata_a_diff,
 ):
     ideal_diff = ideal_difference_from_metadata(
-        positive_items=positive_items,
-        negative_items=negative_items,
+        positive_ids=positive_ids,
+        negative_ids=negative_ids,
         metadata={'a': torch.tensor([0, 0, 0, 0, 1, 1, 1, 1, 1])},
         metadata_weights={'a': .2},
     )
@@ -61,15 +61,15 @@ def test_ideal_difference_from_metadata_no_matches(
 
 
 def test_ideal_difference_from_metadata_a_and_b(
-    positive_items,
-    many_negative_items,
+    positive_ids,
+    many_negative_ids,
     metadata_a,
     metadata_b,
     metadata_a_and_2_diff,
 ):
     ideal_diff = ideal_difference_from_metadata(
-        positive_items=positive_items.repeat(4, 1),
-        negative_items=many_negative_items,
+        positive_ids=positive_ids.repeat(4, 1),
+        negative_ids=many_negative_ids,
         metadata={'a': metadata_a, 'b': metadata_b},
         metadata_weights={'a': .2, 'b': .3},
     )
@@ -106,7 +106,7 @@ def test_adaptive_hinge_loss(positive_scores, many_negative_scores):
 
 
 def test_warp_loss(positive_scores, many_negative_scores):
-    actual = warp_loss(positive_scores, many_negative_scores, num_items=4)
+    actual = warp_loss(positive_scores, many_negative_scores, num_ids=4)
     expected = (11.366 + 72.385) / 4
 
     assert_almost_equal(actual.item(), expected, decimal=3)
@@ -115,15 +115,15 @@ def test_warp_loss(positive_scores, many_negative_scores):
 def test_bpr_loss_metadata(
     positive_scores,
     negative_scores,
-    positive_items,
-    negative_items,
+    positive_ids,
+    negative_ids,
     metadata_a,
 ):
     actual = bpr_loss(
         positive_scores=positive_scores,
         negative_scores=negative_scores,
-        positive_items=positive_items,
-        negative_items=negative_items,
+        positive_ids=positive_ids,
+        negative_ids=negative_ids,
         metadata={'a': metadata_a},
         metadata_weights={'a': 0.2}
     )
@@ -135,15 +135,15 @@ def test_bpr_loss_metadata(
 def test_hinge_loss_metadata(
     positive_scores,
     negative_scores,
-    positive_items,
-    negative_items,
+    positive_ids,
+    negative_ids,
     metadata_a,
 ):
     actual = hinge_loss(
         positive_scores=positive_scores,
         negative_scores=negative_scores,
-        positive_items=positive_items,
-        negative_items=negative_items,
+        positive_ids=positive_ids,
+        negative_ids=negative_ids,
         metadata={'a': metadata_a},
         metadata_weights={'a': 0.2}
     )
@@ -155,16 +155,16 @@ def test_hinge_loss_metadata(
 def test_adaptive_bpr_loss_metadata(
     positive_scores,
     many_negative_scores,
-    positive_items,
-    many_negative_items,
+    positive_ids,
+    many_negative_ids,
     metadata_a,
     metadata_b,
 ):
     actual = adaptive_bpr_loss(
         positive_scores=positive_scores,
         many_negative_scores=many_negative_scores,
-        positive_items=positive_items,
-        negative_items=many_negative_items,
+        positive_ids=positive_ids,
+        negative_ids=many_negative_ids,
         metadata={'a': metadata_a, 'b': metadata_b},
         metadata_weights={'a': 0.2, 'b': 0.3},
     )
@@ -176,16 +176,16 @@ def test_adaptive_bpr_loss_metadata(
 def test_adaptive_hinge_loss_metadata(
     positive_scores,
     many_negative_scores,
-    positive_items,
-    many_negative_items,
+    positive_ids,
+    many_negative_ids,
     metadata_a,
     metadata_b,
 ):
     actual = adaptive_hinge_loss(
         positive_scores=positive_scores,
         many_negative_scores=many_negative_scores,
-        positive_items=positive_items,
-        negative_items=many_negative_items,
+        positive_ids=positive_ids,
+        negative_ids=many_negative_ids,
         metadata={'a': metadata_a, 'b': metadata_b},
         metadata_weights={'a': 0.2, 'b': 0.3}
     )
@@ -197,17 +197,17 @@ def test_adaptive_hinge_loss_metadata(
 def test_warp_loss_metadata(
     positive_scores,
     many_negative_scores,
-    positive_items,
-    many_negative_items,
+    positive_ids,
+    many_negative_ids,
     metadata_a,
     metadata_b,
 ):
     actual = warp_loss(
         positive_scores=positive_scores,
         many_negative_scores=many_negative_scores,
-        num_items=4,
-        positive_items=positive_items,
-        negative_items=many_negative_items,
+        num_ids=4,
+        positive_ids=positive_ids,
+        negative_ids=many_negative_ids,
         metadata={'a': metadata_a, 'b': metadata_b},
         metadata_weights={'a': 0.2, 'b': 0.3},
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -79,6 +79,7 @@ def test_basepipeline_does_not_initialize(train_val_implicit_data):
 
 @pytest.mark.parametrize('change_to_make', ['num_users',
                                             'num_items',
+                                            'negative_sample_type',
                                             'num_negative_samples',
                                             'bad_train_num_negative_samples'])
 def test_mismatched_train_and_val_loaders(train_val_implicit_data, change_to_make):
@@ -95,6 +96,9 @@ def test_mismatched_train_and_val_loaders(train_val_implicit_data, change_to_mak
     elif change_to_make == 'num_items':
         train.num_items = 1
         val.num_items = 2
+    elif change_to_make == 'negative_sample_type':
+        train.negative_sample_type = 'item'
+        val.negative_sample_type = 'user'
     elif change_to_make == 'num_negative_samples':
         train.num_negative_samples = 1
         val.num_negative_samples = 2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -787,6 +787,51 @@ def test_implicit_model(implicit_model,
 
 
 @pytest.mark.parametrize('model_type', ['with_lightning', 'no_lightning'])
+def test_implicit_model_user_negative_sample_type(
+    implicit_model_user_negative_sample_type,
+    implicit_model_no_lightning_user_negative_sample_type,
+    train_val_implicit_data_user_negative_sample_type,
+    model_type
+):
+    if model_type == 'with_lightning':
+        model = implicit_model_user_negative_sample_type
+    elif model_type == 'no_lightning':
+        model = implicit_model_no_lightning_user_negative_sample_type
+
+    train, val = train_val_implicit_data_user_negative_sample_type
+
+    item_preds = model.get_item_predictions(user_id=0,
+                                            unseen_items_only=True,
+                                            sort_values=True)
+
+    assert isinstance(item_preds, pd.Series)
+    assert len(item_preds) > 0
+    assert len(item_preds) < len(train)
+
+    item_similarities = model.item_item_similarity(item_id=42)
+    assert item_similarities.index[0] == 42
+
+    user_preds = model.get_user_predictions(item_id=0,
+                                            unseen_users_only=True,
+                                            sort_values=True)
+
+    assert isinstance(user_preds, pd.Series)
+    assert len(user_preds) > 0
+    assert len(user_preds) < len(train)
+
+    user_similarities = model.user_user_similarity(user_id=42)
+    assert user_similarities.index[0] == 42
+    # TODO: negative user sampling is not implemented in model metrics yet
+    # uncomment the following lines once implemented
+    # mapk_score = evaluate_in_batches([mapk], val, model)
+
+    # The metrics used for evaluation have been determined through 30
+    # trials of training the model and using the mean - 5 * std. dev.
+    # as the minimum score the model must achieve to pass the test.
+    # assert mapk_score > 0.044
+
+
+@pytest.mark.parametrize('model_type', ['with_lightning', 'no_lightning'])
 def test_explicit_model(explicit_model,
                         explicit_model_no_lightning,
                         train_val_explicit_data,


### PR DESCRIPTION
## Describe the big picture - why are we doing this?
This PR adds the ability to do negative user sampling in the `BasePipeline` and the loss files. Again, I did not edit the `changelog` nor `_version`, that will come in the next PR when all the parts of negative user sampling have been added!

## Any additional details to clarify code in the PR?

## How is this tested?
On an EC2 instance in Docker, all tests pass.

## Pull Request Checklist
 - [x] Pull request includes a description of why we are doing this
 - [ ] ``CHANGELOG`` has been updated
 - [ ] Version in ``_version.py`` has been updated
 - [x] All tests in the ``tests`` folder pass with a local build
 - [ ] ``README`` has been updated (if applicable)
 - [ ] Documentation in ``docs`` has been updated (if applicable)
 - [ ] ``requirements.txt`` and ``requirements-dev.txt`` have been recompiled (if applicable)
 - [x] Docker image can be built using ``docker build -t collie .``

## Screenshots or GIFs?
![](https://media.giphy.com/media/LBt05Kj5Ahxni/giphy.gif)